### PR TITLE
add package init functions when algo is rta

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -60,6 +60,26 @@ func mainPackages(pkgs []*ssa.Package) ([]*ssa.Package, error) {
 	return mains, nil
 }
 
+// initFuncs returns all package init functions
+func initFuncs(pkgs []*ssa.Package) ([]*ssa.Function, error) {
+	var inits []*ssa.Function
+	for _, p := range pkgs {
+		if p == nil {
+			continue
+		}
+		for name, member := range p.Members {
+			fun, ok := member.(*ssa.Function)
+			if !ok {
+				continue
+			}
+			if name == "init" || strings.HasPrefix(name, "init#") {
+				inits = append(inits, fun)
+			}
+		}
+	}
+	return inits, nil
+}
+
 //==[ type def/func: analysis   ]===============================================
 type analysis struct {
 	opts      *renderOpts
@@ -115,6 +135,15 @@ func (a *analysis) DoAnalysis(
 		for _, main := range mains {
 			roots = append(roots, main.Func("main"))
 		}
+		
+		inits, err := initFuncs(prog.AllPackages())
+		if err != nil {
+			return err
+		}
+		for _, init := range inits {
+			roots = append(roots, init)
+		}
+
 		graph = rta.Analyze(roots, true).CallGraph
 	case CallGraphTypePointer:
 		mains, err := mainPackages(prog.AllPackages())


### PR DESCRIPTION
Package init method is missed under rta algo. For example:

main.go

```
package main

func main() {
    method() 
}

func init() {
    method()    
}

func method() {
}
```

go.mod
```
module example.com/graph/example_init

go 1.20
```

`go-callvis -algo rta example.com/graph/example_init`

![image](https://github.com/user-attachments/assets/994ad896-abd4-4f8c-9ef5-10893b2dd3cb)
